### PR TITLE
0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 authors = ["Noel Horváth <noelhorvath69@gmail.com>"]
 categories = ["no-std", "rust-patterns", "mathematics"]
-description = "Collection of 100% safe macros for creating NonZero{Integer} types more easily."
-edition = "2018"
+description = "Collection of 100% safe macros for creating core::num::NonZero{Integer} types more easily."
+edition = "2021"
 keywords = ["nonzero", "non-zero", "no_std", "no-std", "const"]
 license = "Zlib OR Apache-2.0 OR MIT"
 name = "nz"
 readme = "README.md"
 repository = "https://github.com/noelhorvath/nz"
 rust-version = "1.56.0"
-version = "0.2.1"
+version = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 authors = ["Noel Horváth <noelhorvath69@gmail.com>"]
 categories = ["no-std", "rust-patterns", "mathematics"]
-description = "Collection of 100% safe macros for creating numeric core::num::NonZero{Integer} types more easily."
-edition = "2021"
+description = "Collection of 100% safe macros for creating NonZero{Integer} types more easily."
+edition = "2018"
 keywords = ["nonzero", "non-zero", "no_std", "no-std", "const"]
 license = "Zlib OR Apache-2.0 OR MIT"
 name = "nz"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # nz
 
-[![crates.io](https://img.shields.io/crates/v/nz?style=for-the-badge)](https://crates.io/crates/nz)
-[![docs](https://img.shields.io/docsrs/nz/latest?style=for-the-badge)](https://docs.rs/nz)
-[![license](https://img.shields.io/badge/License-MIT_OR_Zlib_OR_APACHE_2.0-blue?style=for-the-badge)](#license)
-[![rust](https://img.shields.io/github/actions/workflow/status/noelhorvath/nz/rust.yml?event=push&style=for-the-badge)](https://github.com/noelhorvath/nz/actions/workflows/rust.yml)
-[![msrv](https://img.shields.io/badge/MSRV-1.56.0-F21D1D?style=for-the-badge)](https://releases.rs/docs/1.56.0/)
-![unsafety](https://img.shields.io/badge/unsafe-forbidden-brightgreen?style=for-the-badge)
+[![github]](https://github.com/noelhorvath/zn)
+[![crates.io]](https://crates.io/crates/nz)
+[![docs.rs]](https://docs.rs/nz)
+[![rust-ci]](https://github.com/noelhorvath/nz/actions/workflows/rust.yml)
+[![msrv]](https://releases.rs/docs/1.56.0/)
+![unsafety]
+[![license](#license)
+
+[github]: https://img.shields.io/badge/github-8da0cb?style=for-the-badge&logo=github
+[crates.io]: https://img.shields.io/crates/v/nz?style=for-the-badge&logo=rust
+[docs.rs]: https://img.shields.io/docsrs/nz/latest?style=for-the-badge&logo=docs.rs
+[rust-ci]: https://img.shields.io/github/actions/workflow/status/noelhorvath/nz/rust.yml&style=for-the-badge
+[msrv]: https://img.shields.io/badge/MSRV-1.56.0-F21D1D?style=for-the-badge&logo=rust
+[unsafety]: https://img.shields.io/badge/unsafe-forbidden-brightgreen?style=for-the-badge&logo=rust
+[license]: https://img.shields.io/badge/License-MIT_OR_Zlib_OR_APACHE_2.0-blue?style=for-the-badge
 
 The `nz` crate provides a collection of macros that simplify the creation
 of non-zero numerics implemented in [`core::num`](https://doc.rust-lang.org/core/num/index.html).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,139 @@
-#![doc = include_str!("../README.md")]
+//! # nz
+//!
+//! [![github]](https://github.com/noelhorvath/zn)
+//! [![crates.io]](https://crates.io/crates/nz)
+//! [![docs.rs]](https://docs.rs/nz)
+//! [![msrv]](https://releases.rs/docs/1.56.0/)
+//!
+//! [github]: https://img.shields.io/badge/github-8da0cb?style=for-the-badge&logo=github
+//! [crates.io]: https://img.shields.io/crates/v/nz?style=for-the-badge&logo=rust
+//! [docs.rs]: https://img.shields.io/docsrs/nz/latest?style=for-the-badge&logo=docs.rs
+//! [msrv]: https://img.shields.io/badge/MSRV-1.56.0-F21D1D?style=for-the-badge&logo=rust
+//!
+//!
+//! The `nz` crate provides a collection of macros that simplify the creation
+//! of non-zero numerics implemented in [`core::num`](https://doc.rust-lang.org/core/num/index.html).
+//! With these macros, you can easily generate constants of all the `NonZero`
+//! types using literals, constant values or expressions at compile time.
+//!
+//! ## Features
+//!
+//! * No unsafe code
+//! * No dependencies
+//! * `no_std` compatible
+//! * Supports all `core::num::NonZero{Integer}` types
+//! * Compile-time evaluation and zero detection
+//!
+//! ## `NonZero` macros
+//!
+//! | Type | Macro |
+//! |------|-------|
+//! | [`NonZeroI8`][core::num::NonZeroI8] | [`nz::i8!`][crate::i8] |
+//! | [`NonZeroI16`][core::num::NonZeroI16] | [`nz::i16!`][crate::i16] |
+//! | [`NonZeroI32`][core::num::NonZeroI32] | [`nz::i32!`][crate::i32] |
+//! | [`NonZeroI64`][core::num::NonZeroI64] | [`nz::i64!`][crate::i64] |
+//! | [`NonZeroI128`][core::num::NonZeroI128] | [`nz::i128!`][crate::i128] |
+//! | [`NonZeroIsize`][core::num::NonZeroIsize] | [`nz::isize!`][crate::isize] |
+//! | [`NonZeroU8`][core::num::NonZeroU8] | [`nz::u8!`][crate::u8] |
+//! | [`NonZeroU16`][core::num::NonZeroU16] | [`nz::u16!`][crate::u16] |
+//! | [`NonZeroU32`][core::num::NonZeroU32] | [`nz::u32!`][crate::u32] |
+//! | [`NonZeroU64`][core::num::NonZeroU64] | [`nz::u64!`][crate::u64] |
+//! | [`NonZeroU128`][core::num::NonZeroU128] | [`nz::u128!`][crate::u128] |
+//! | [`NonZeroUsize`][core::num::NonZeroUsize] | [`nz::usize!`][crate::usize] |
+//!
+//! ## Basic usage
+//!
+//! ```rust
+//! use core::num::NonZeroU8;
+//! // A `NonZeroU8` type can be constructed by different types
+//! // of arguments when using the matching macro.
+//! // such argument can be a numeric literal
+//! const NZ_MIN: NonZeroU8 = nz::u8!(1);
+//! let nz_two = nz::u8!(2);
+//! // or a constant value
+//! const NZ_MAX: NonZeroU8 = nz::u8!(u8::MAX);
+//! const SIX: u8 = 6;
+//! let six = nz::u8!(SIX);
+//! // or even a constant expression
+//! const RES: NonZeroU8 = nz::u8!({ 3 + 7 } - NZ_MIN.get());
+//! // non-constant expression results in a compile-time error
+//! // which is caused by `nz_two` in this case
+//! // const OUTPUT: NonZeroU8 = nz::u8!({ 3 + 7 } - nz_two.get());
+//! let res = nz::u8!((NZ_MIN.get() & NZ_MAX.get()) + 7);
+//! let five = nz::u8!({ const FIVE: u8 = 5; FIVE });
+//! # assert_eq!(1, NZ_MIN.get());
+//! # assert_eq!(2, nz_two.get());
+//! # assert_eq!(6, six.get());
+//! # assert_eq!(5, five.get());
+//! # assert_eq!(9, RES.get());
+//! # assert_eq!(8, res.get());
+//! ```
+//!
+//! ## Limitations
+//!
+//! ### const fn
+//!
+//! Declarative macros, such as all the `nz` macros, cannot be used with
+//! constant function arguments since they are not considered constant
+//! values, as demonstrated in the code below.
+//!
+//! ```rust, compile_fail
+//! use core::num::NonZeroU64;
+//!
+//! const fn wrapping_add_nz(a: u64, b: NonZeroU64) -> NonZeroU64 {
+//!     // `a` and `b` is not constant which results
+//!     // in a compile-time error when passed to
+//!     // `nz::u64!` in an expression
+//!     nz::u64!(a.wrapping_add(b.get()))
+//! }
+//! let nz = wrapping_add_nz(2, nz::u64!(1));
+//! ```
+//!
+//! ### const hygiene
+//!
+//! When constants are used in a declarative macro, specifically in the
+//! most outer scope where a constant can be declared, there is a possibility
+//! of cyclic dependency when an expression is expected as an argument and an
+//! outer constant is used within that expression. This *collision* can occur
+//! if any of the inner constants share the same identifier as the outer constant
+//! after the macro is expanded at compile-time. The code snippet below demonstrates
+//! this scenario.
+//!
+//! ```rust, compile_fail
+//! use core::num::NonZeroU16;
+//!
+//! const NZ: NonZeroU16 = nz::u16!(0xA3FE);
+//! const CHECK_ZERO: NonZeroU16 = nz::u16!(777);
+//! // although `CHECK_ZERO` is used in `nz::u16!` macro, it will not result in
+//! // an error when a constant with the same name is passed as part
+//! // of a constant expression, because this inner macro constant is not
+//! // declared in the most outer scope
+//! const OK: NonZeroU16 = nz::u16!(CHECK_ZERO.get());
+//! // using `NZ` is fine for the same reason
+//! const ___NZ___INTERNAL___NUM___1___: u16
+//!     = nz::u16!(NZ.get()).get();
+//! // using `___NZ___INTERNAL___NUM___1___` constant as the argument
+//! // causes compile-time error in the code line below, because the
+//! // internal macro constant has the same identifier as the constant
+//! // specified in the macro argument
+//! const _: NonZeroU16 = nz::u16!(___NZ___INTERNAL___NUM___1___);
+//! ```
+//!
+//! More concisely, the problem is:
+//!
+//! ```rust, compile_fail
+//! const X: u8 = X;
+//! ```
+//!
+//! This *collision* between the outer and inner constants results in a compile-time
+//! error[^error], because the inner macro constant depends on itself, creating
+//! a cyclic dependency.
+//!
+//! [^error]: [`[E0391]`](https://doc.rust-lang.org/error_codes/E0391.html),
 #![no_std]
 #![forbid(unsafe_code)]
 
-/// Generates the non-zero macro for the specified `NonZero{Integer}` type.
+/// Generates the non-zero macro for the specified non-zero numeric type.
 macro_rules! gen_non_zero_macros {
     (
         const $const_id:ident;


### PR DESCRIPTION
# Changelog 
- Add crate documentation directly to `lib.rs` instead of including it from `README.md` (70dd1e58d9602b3cde48fa180e795acffde08051)
- Modify package description in `Cargo.toml` (a5271c73a430db577ba98059cb84f3baf7aa0d4f)
- Update package version to `0.2.2` (a2d08a91affbbdda68f0c4d81d7c31578bd7bc4b)
- Update badges in `README.md` (f509a38d7a31b629c42ebd95ff0b29f5a206e014)